### PR TITLE
feat: add one-command local app startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,19 +33,30 @@ Install dependencies:
 pnpm install
 ```
 
-Start local Postgres:
+Start the local development stack:
+
+```bash
+pnpm dev:local
+```
+
+This starts the local Postgres container, waits for the database to accept
+connections, generates Prisma client code, applies committed migrations, and
+starts the Next.js dev server at `http://localhost:3000`.
+It uses `DATABASE_URL` from the root `.env` when present, otherwise it defaults
+to the local Docker Compose database.
+
+The lower-level commands remain available for troubleshooting or targeted work:
 
 ```bash
 docker compose up -d postgres
-```
-
-Run Prisma commands:
-
-```bash
 pnpm db:generate
 pnpm db:migrate
+pnpm dev:web
 pnpm db:studio
 ```
+
+Use `pnpm db:migrate` when actively changing the Prisma schema and creating or
+applying development migrations.
 
 Build and start the production web container after the database schema is up to date:
 
@@ -60,7 +71,7 @@ container never applies them automatically.
 For local web development without building the production container, run:
 
 ```bash
-pnpm --filter @appsec-workbench/web dev
+pnpm dev:web
 ```
 
 Run the real repository inventory sync:

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 
 const appDirectory = dirname(fileURLToPath(import.meta.url));
 
-loadEnvConfig({ path: resolve(appDirectory, "../../.env") });
+loadEnvConfig({ path: resolve(appDirectory, "../../.env"), quiet: true });
 
 const nextConfig: NextConfig = {
   output: "standalone",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
     "test:unit": "npm --prefix apps/web run test:unit && npm --prefix apps/cli run test:unit",
     "test:unit:web": "npm --prefix apps/web run test:unit",
     "test:unit:cli": "npm --prefix apps/cli run test:unit",
+    "dev:local": "node scripts/dev-local.mjs",
     "dev:web": "pnpm --filter @appsec-workbench/web dev",
     "cli": "pnpm --filter @appsec-workbench/cli",
     "db:generate": "pnpm --filter @appsec-workbench/db db:generate",
     "db:migrate": "pnpm --filter @appsec-workbench/db db:migrate",
+    "db:migrate:deploy": "pnpm --filter @appsec-workbench/db db:migrate:deploy",
     "db:studio": "pnpm --filter @appsec-workbench/db db:studio"
   },
   "devDependencies": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "db:generate": "cd ../.. && prisma generate --schema packages/db/prisma/schema.prisma",
     "db:migrate": "cd ../.. && prisma migrate dev --schema packages/db/prisma/schema.prisma",
+    "db:migrate:deploy": "cd ../.. && prisma migrate deploy --schema packages/db/prisma/schema.prisma",
     "db:studio": "cd ../.. && prisma studio --schema packages/db/prisma/schema.prisma"
   },
   "dependencies": {

--- a/scripts/dev-local.mjs
+++ b/scripts/dev-local.mjs
@@ -1,0 +1,152 @@
+import { spawn } from "node:child_process";
+import { config as loadEnv } from "dotenv";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDirectory, "..");
+const localDatabaseUrl = "postgresql://appsec:appsec@localhost:5432/appsec_local";
+const postgresWaitTimeoutMs = 60_000;
+const postgresPollIntervalMs = 2_000;
+
+loadEnv({ path: resolve(repoRoot, ".env"), quiet: true });
+
+const childEnvironment = {
+  ...process.env,
+  DATABASE_URL: process.env.DATABASE_URL || localDatabaseUrl,
+};
+
+function run(command, args, options = {}) {
+  return new Promise((resolveRun, rejectRun) => {
+    const child = spawn(command, args, {
+      cwd: repoRoot,
+      env: childEnvironment,
+      stdio: "inherit",
+      shell: process.platform === "win32",
+      ...options,
+    });
+
+    child.on("error", (error) => {
+      rejectRun(error);
+    });
+
+    child.on("exit", (code, signal) => {
+      if (code === 0) {
+        resolveRun();
+        return;
+      }
+
+      const detail = signal ? `signal ${signal}` : `exit code ${code}`;
+      rejectRun(new Error(`${command} ${args.join(" ")} failed with ${detail}.`));
+    });
+  });
+}
+
+function check(command, args) {
+  return new Promise((resolveCheck) => {
+    const child = spawn(command, args, {
+      cwd: repoRoot,
+      env: childEnvironment,
+      stdio: "ignore",
+      shell: process.platform === "win32",
+    });
+
+    child.on("error", () => {
+      resolveCheck(false);
+    });
+
+    child.on("exit", (code) => {
+      resolveCheck(code === 0);
+    });
+  });
+}
+
+function sleep(ms) {
+  return new Promise((resolveSleep) => {
+    setTimeout(resolveSleep, ms);
+  });
+}
+
+async function waitForPostgres() {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < postgresWaitTimeoutMs) {
+    const isReady = await check("docker", [
+      "compose",
+      "exec",
+      "-T",
+      "postgres",
+      "pg_isready",
+      "-U",
+      "appsec",
+      "-d",
+      "appsec_local",
+    ]);
+
+    if (isReady) {
+      return;
+    }
+
+    await sleep(postgresPollIntervalMs);
+  }
+
+  throw new Error("Postgres did not become ready within 60 seconds.");
+}
+
+function startWebServer() {
+  console.log("Starting web dev server at http://localhost:3000...");
+
+  const child = spawn("pnpm", ["dev:web"], {
+    cwd: repoRoot,
+    env: childEnvironment,
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+
+  const forwardSignal = (signal) => {
+    if (!child.killed) {
+      child.kill(signal);
+    }
+  };
+
+  process.once("SIGINT", forwardSignal);
+  process.once("SIGTERM", forwardSignal);
+
+  child.on("error", (error) => {
+    console.error(`Failed to start the web dev server: ${error.message}`);
+    process.exitCode = 1;
+  });
+
+  child.on("exit", (code, signal) => {
+    process.removeListener("SIGINT", forwardSignal);
+    process.removeListener("SIGTERM", forwardSignal);
+
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+
+    process.exitCode = code ?? 1;
+  });
+}
+
+async function main() {
+  console.log("Starting Postgres...");
+  await run("docker", ["compose", "up", "-d", "postgres"]);
+
+  console.log("Waiting for Postgres...");
+  await waitForPostgres();
+
+  console.log("Generating Prisma client...");
+  await run("pnpm", ["db:generate"]);
+
+  console.log("Applying database migrations...");
+  await run("pnpm", ["db:migrate:deploy"]);
+
+  startWebServer();
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Add `pnpm dev:local` to start Postgres, prepare Prisma, apply migrations, and launch the Next.js dev server.
- Add database migration deployment scripts for local startup and production-safe schema application.
- Document the streamlined local development workflow and preserve lower-level troubleshooting commands.
- Quiet Next.js environment loading to reduce startup noise.

## Testing

- Not run.